### PR TITLE
Bugfix/docs publish

### DIFF
--- a/documentation/publish.env
+++ b/documentation/publish.env
@@ -16,8 +16,8 @@ PUBLISH_REMOTE=${PUBLISH_REMOTE:-$(git config --get remote.origin.url)}
 # It is not directly generated from the current active branch.
 # The repository will be cloned from the current origin remote into a temporary workspace and generated using
 # "make build"
-#DOCUMENTATION_SOURCE_BRANCH=develop
-DOCUMENTATION_SOURCE_BRANCH=bugfix/docs-publish
+DOCUMENTATION_SOURCE_BRANCH=master
+#DOCUMENTATION_SOURCE_BRANCH=bugfix/docs-publish
 
 ## This branch will be created during publication. If it exists it will be destroyed
 # A new orphan branch with the label "PUBLISH_BRANCH" will be created containing only a "docs" directory. 

--- a/documentation/publish.env
+++ b/documentation/publish.env
@@ -7,13 +7,17 @@
 PROHIBITED_REMOTES="git@github.com:eclipse/adore.git https://github.com/eclipse/adore.git"
 
 ## The remote where the documentation will be published
-PUBLISH_REMOTE=git@github.com:DLR-TS/adore
+## The default unless otherwise specified will be the "origin" remote
+#PUBLISH_REMOTE=git@github.com:DLR-TS/adore
+PUBLISH_REMOTE=${PUBLISH_REMOTE:-$(git config --get remote.origin.url)}
+
 
 ## The documentation will be generated from the "DOCUMENTATION_SOURCE_BRANCH"
 # It is not directly generated from the current active branch.
 # The repository will be cloned from the current origin remote into a temporary workspace and generated using
 # "make build"
-DOCUMENTATION_SOURCE_BRANCH=develop
+#DOCUMENTATION_SOURCE_BRANCH=develop
+DOCUMENTATION_SOURCE_BRANCH=bugfix/docs-publish
 
 ## This branch will be created during publication. If it exists it will be destroyed
 # A new orphan branch with the label "PUBLISH_BRANCH" will be created containing only a "docs" directory. 

--- a/documentation/publish_gh-pages.sh
+++ b/documentation/publish_gh-pages.sh
@@ -10,7 +10,7 @@ trap cleanup EXIT
 source publish.env
 
 function cleanup {
-  rm -rf "${CLONE_DIRECTORY}"
+  #rm -rf "${CLONE_DIRECTORY}"
   echo "Deleted temp working directory ${CLONE_DIRECTORY}"
 }
 
@@ -47,9 +47,9 @@ CLONE_DIRECTORY="$(mktemp -d)"
 git_url="${PUBLISH_REMOTE}"
 
 
-if [[ ! -d "${DOCS_DIRECTORY}" ]]; then
-    exiterr "ERROR: docs directory: ${DOCS_DIRECTORY} does not exist.  Did you call 'make build_gh-pages'" 
-fi
+#if [[ ! -d "${DOCS_DIRECTORY}" ]]; then
+#    exiterr "ERROR: docs directory: ${DOCS_DIRECTORY} does not exist.  Did you call 'make build_gh-pages'" 
+#fi
 
 
 if [[ $PROHIBITED_REMOTES == *"$git_url"* ]]; then


### PR DESCRIPTION
modified the documentation/publish.env file to reference the master branch instead of the develop branch. 
With "make publish" from the documentation folder, documentation from the `remotes/origin/master` will be published to the `remotes/origin/gh-pages` and will be available via `https://<username/organization>.github.io/adore/` e.g., https://dlr-ts.github.io/adore/