### PR TITLE
updated adore_cli + make_gadgets, fixed DOCKER_GID

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ MAKE_GADGETS_DIR:=tools/adore_cli/make_gadgets
 
 MAKE_GADGETS_FILES := $(wildcard $(MAKE_GADGETS_DIR)/*)
 ifeq ($(MAKE_GADGETS_FILES),)
-    $(shell git submodule update --init)
+    $(shell git submodule update --init --recursive)
 endif
 
 

--- a/Makefile
+++ b/Makefile
@@ -22,10 +22,8 @@ VENDOR_PATH:=${ROOT_DIR}/vendor
 ROS_NODE_PATH:=${ROOT_DIR}/ros2_workspace/src
 ADORE_LIBRARY_PATH:=${ROOT_DIR}/libraries
 #BRANCH:=$(shell make get_sanitized_branch_name)
-BRANCH:=$(shell bash ${MAKE_GADGETS_DIR}/tools/branch_name.sh)
-ADORE_CLI_BRANCH:=$(shell bash ${MAKE_GADGETS_DIR}/tools/branch_name.sh)
-ADORE_CLI_IMAGE:=$(shell cd tools/adore_cli && make image_adore_cli)_${BRANCH}
-ADORE_CLI_CONTAINER_NAME:=$(subst :,_,${ADORE_CLI_IMAGE})
+PARENT_BRANCH:= $(shell cd "${ROOT_DIR}" && bash $(MAKE_GADGETS_DIR)/tools/branch_name.sh 2>/dev/null || echo NOBRANCH)
+PARENT_SHORT_HASH:=$(shell cd "${ROOT_DIR}" && git rev-parse --short HEAD 2>/dev/null || echo NOHASH)
 
 include ${SUBMODULES_PATH}/adore_cli/ci_teststand/ci_teststand.mk
 include utils.mk

--- a/vendor/libOpenDRIVE/.dockerignore
+++ b/vendor/libOpenDRIVE/.dockerignore
@@ -1,0 +1,1 @@
+libOpenDRIVE/build


### PR DESCRIPTION
## Description

- Updated tools/adore_cli/make_gadgets to improve the DOCKER_GID make variable.  If there are multiple entries in the /etc/group for docker the previous implementation would return multiple group ids.  This change makes it more reliable if there are multiple entries in the /etc/group file for the same docker group.

 - Also added .dockerignore to libOpenDRIVE to improve docker caching
- Update the `adore_cli` .zshrc file to include git hash info in the PROMPT
Old Prompt:
![image](https://github.com/user-attachments/assets/3d18f6f2-11c4-4864-8197-a2bb554cb2e4)
New Prompt:
![image](https://github.com/user-attachments/assets/ba4e5788-569d-412a-ad80-f4dfce6798e8)

- Updated/changed `adore_cli` container name and image names
https://github.com/DLR-TS/adore_cli/blob/fcc2fd0eb510d77bff964f95a5869b8f19d63df2/adore_cli.mk#L27-L36
  

## Type of Change

Please delete options that are not relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (adds or updates documentation)
- [ ] Refactor (non-breaking change for code readability/structure)
- [ ] Other (please describe):

