### PR TITLE
Support ADORe API in image release

### DIFF
--- a/.github/workflows/adore_ci.yaml
+++ b/.github/workflows/adore_ci.yaml
@@ -5,7 +5,6 @@ on:
     branches:
       - 'master'
       - 'develop'
-      - '**'
   pull_request:
     branches:
       - '**'

--- a/.github/workflows/adore_ci.yaml
+++ b/.github/workflows/adore_ci.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - 'master'
       - 'develop'
+      - '**'
   pull_request:
     branches:
       - '**'

--- a/setup.sh
+++ b/setup.sh
@@ -30,4 +30,5 @@ else
     echo "ERROR: script designed to be sourced. Call again with 'source setup.sh'" >&2
     exit 1
 fi
-source /tmp/adore/tools/adore_api/adore_api.sh
+
+source ${SCRIPT_DIRECTORY}/tools/adore_api/adore_api.sh

--- a/tools/adore_release/Containerfile
+++ b/tools/adore_release/Containerfile
@@ -8,8 +8,17 @@ ENV ADORE_SOURCE_DIRECTORY /ros2_ws
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt update -y \
 	&& apt upgrade -y --no-install-recommends \
-	&& apt install -y --no-install-recommends python3-pyproj ros-jazzy-foxglove-bridge ros-jazzy-cv-bridge \
+	&& apt install -y --no-install-recommends \
+		ros-jazzy-foxglove-bridge \
+		ros-jazzy-cv-bridge \
+	&& apt install -y --no-install-recommends \
+		python3-pip \
+		python3-pyproj \
 	&& rm -rf /var/lib/apt/lists/*
+
+RUN python3 -m pip install --break-system-packages \
+	flask \
+	flask-cors
 
 RUN mkdir /ros2_ws
 COPY build /ros2_ws

--- a/tools/adore_release/Containerfile
+++ b/tools/adore_release/Containerfile
@@ -9,16 +9,16 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt update -y \
 	&& apt upgrade -y --no-install-recommends \
 	&& apt install -y --no-install-recommends \
+		wget \
 		ros-jazzy-foxglove-bridge \
 		ros-jazzy-cv-bridge \
-	&& apt install -y --no-install-recommends \
 		python3-pip \
 		python3-pyproj \
 	&& rm -rf /var/lib/apt/lists/*
 
 RUN python3 -m pip install --break-system-packages \
-	flask \
-	flask-cors
+		flask \
+		flask-cors
 
 RUN mkdir /ros2_ws
 COPY build /ros2_ws

--- a/tools/adore_release/Containerfile
+++ b/tools/adore_release/Containerfile
@@ -1,9 +1,11 @@
 # syntax=docker/dockerfile:1.7-labs
 FROM docker.io/ros:jazzy-ros-base
 
-ENV DEBIAN_FRONTEND noninteractive
+# This env variable is used by tools
+ENV ADORE_SOURCE_DIRECTORY /ros2_ws
 
-# Install minimal requirements for 
+# Install minimal requirements for nodes
+ENV DEBIAN_FRONTEND noninteractive
 RUN apt update -y \
 	&& apt upgrade -y --no-install-recommends \
 	&& apt install -y --no-install-recommends python3-pyproj ros-jazzy-foxglove-bridge ros-jazzy-cv-bridge \

--- a/tools/adore_release/Containerfile
+++ b/tools/adore_release/Containerfile
@@ -10,10 +10,13 @@ RUN apt update -y \
 	&& apt upgrade -y --no-install-recommends \
 	&& apt install -y --no-install-recommends \
 		wget \
+		yq \
+		sqlite3 \
 		ros-jazzy-foxglove-bridge \
 		ros-jazzy-cv-bridge \
 		python3-pip \
 		python3-pyproj \
+		python3-ujson \
 	&& rm -rf /var/lib/apt/lists/*
 
 RUN python3 -m pip install --break-system-packages \


### PR DESCRIPTION
This PR fixes the source path for ADORe API and adds requirements to the CI image. After this change, the ADORe API is automatically available after start of the container.