### PR TITLE
updated helix to version 25.07.1

### DIFF
--- a/vendor/helix/Makefile
+++ b/vendor/helix/Makefile
@@ -7,8 +7,7 @@ ARCH?=$(shell uname -m)
 DOCKER_PLATFORM?=linux/$(ARCH)
 CROSS_COMPILE?=$(shell if [ "$(shell uname -m)" != "$(ARCH)" ]; then echo "true"; else echo "false"; fi)
 
-
-URL:=https://github.com/helix-editor/helix/releases/download/25.01.1/helix_25.1.1-1_amd64.deb
+URL:=https://github.com/helix-editor/helix/releases/download/25.07.1/helix_25.7.1-1_amd64.deb
 
 .PHONY: build
 build:


### PR DESCRIPTION
## Description

Updated the version of helix used from 25.1 to 25.7, adding features such as a file tree and other QoL.

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] My last commit was made with the `--signoff` flag as required by the Eclipse Foundation.
- [ ] I have commented my code, particularly in hard-to-understand areas and provided a README.md when necessary.
