### PR TITLE
Revert "Fixed publish_gh-pages"

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -123,9 +123,6 @@ docs: setup_colcon_src
 ci: setup_colcon_src
     cd "$WORKSPACE_ROOT" && .docker/scripts/run_ci.sh
 
-publish:
-    cd "$WORKSPACE_ROOT" && documentation/publish_gh-pages.sh
-
 # -------------------------------------------------------------------
 # ADORe API control (via tools/adore_api/adore_api.sh)
 # -------------------------------------------------------------------

--- a/documentation/publish_gh-pages.sh
+++ b/documentation/publish_gh-pages.sh
@@ -46,9 +46,9 @@ if [[ $PROHIBITED_REMOTES == *"$git_url"* ]]; then
 fi
 
 read -p "Should the remote publish branch: ${PUBLISH_BRANCH} be deleted? (y/n): " answer
-if [[ $answer == [Yy]* ]]; then
-    git push ${PUBLISH_REMOTE} --delete "${PUBLISH_BRANCH}" || true
-    git branch -d "${PUBLISH_BRANCH}" || true
+if ! [[ $answer == [Yy] ]]; then
+    git push ${PUBLISH_REMOTE} --delete "${PUBLISH_BRANCH}"
+    git branch -d "${PUBLISH_BRANCH}"
 fi
 
 cd "${CLONE_DIRECTORY}"
@@ -58,32 +58,10 @@ git clone --depth 1 --single-branch -b "${DOCUMENTATION_SOURCE_BRANCH}" "${git_u
 cd ${CLONE_DIRECTORY}/adore
 git checkout --orphan "${PUBLISH_BRANCH}"
 
-# Build documentation block
 {
-    cd ${CLONE_DIRECTORY}/adore/documentation
-    
-    echo "Building documentation in ${PWD}..."
-    
-    # Justfile logic: docs_build_mkdocs
-    mkdir -p mkdocs/docs
-    rm -rf mkdocs/docs/generated mkdocs/site
-    
-    cp -r technical_reference_manual mkdocs/docs/technical_reference_manual
-    
-    echo "Generaring docs with gen_docs.py..."
-    python3 mkdocs/gen_docs.py
-    
-    echo "Running mkdocs build..."
-    (cd mkdocs && mkdocs build)
-
-    # Justfile logic: docs_build
-    rm -rf docs
-    mkdir -p docs
-    cp -r mkdocs/site docs/mkdocs
-    cp -r mkdocs/img docs/mkdocs
-    cp -r mkdocs/stylesheets docs/mkdocs
-    cp -r mkdocs/overrides docs/mkdocs
-} || exiterr "Documentation build failed"
+cd ${CLONE_DIRECTORY}/adore/documentation
+make build
+}
 
 cd ${CLONE_DIRECTORY}/adore
 git reset
@@ -94,13 +72,6 @@ if [[ "${PUBLISH_DIRECTORY}" == "." ]]; then
     cp -r ${CLONE_DIRECTORY}/adore/documentation/docs/* .
     git add . --force
 else
-    # Ensure parent directory exists if nested
-    mkdir -p $(dirname "${PUBLISH_DIRECTORY}")
-    
-    # If PUBLISH_DIRECTORY exists, we might want to clear it or just overwrite.
-    # The original script did mv, which implies the target should probably be replaced or filled.
-    # Since we are in a fresh orphan branch or clean state (mostly), we can just move.
-    rm -rf "${PUBLISH_DIRECTORY}"
     mv ${CLONE_DIRECTORY}/adore/documentation/docs "${PUBLISH_DIRECTORY}"
     git add "${PUBLISH_DIRECTORY}" --force
 fi


### PR DESCRIPTION
Reverts eclipse-adore/adore#77

Expected Behavior:
calling the `publish_gh-pages.sh` script should successfully build and publish the ghpages website including the technical reference manual to `https://eclipse-adore.github.io/adore`. 

Actual Behavior:
After updating the `publish.env` and removing the prohibited remote for git@github.com:eclipse-adore/adore.git
invoking the `publish_gh-pages.sh` results in the following error:
```
Copied /tmp/tmp.XG16AbXwBH/adore/documentation/index.md -> /tmp/tmp.XG16AbXwBH/adore/documentation/mkdocs/docs/index.md                                       
Copied /tmp/tmp.XG16AbXwBH/adore/README.md -> /tmp/tmp.XG16AbXwBH/adore/documentation/mkdocs/docs/generated/README.md                                         
Copied /tmp/tmp.XG16AbXwBH/adore/tools/adore_api/README.md -> /tmp/tmp.XG16AbXwBH/adore/documentation/mkdocs/docs/generated/tools/adore_api/README.md         
Copied /tmp/tmp.XG16AbXwBH/adore/adore_scenarios/README.md -> /tmp/tmp.XG16AbXwBH/adore/documentation/mkdocs/docs/generated/adore_scenarios/README.md         
Running mkdocs build...                                                                                                                                       
Error: MkDocs encountered an error parsing the configuration file: while constructing a Python object                                                         
cannot find module 'materialx.emoji' (No module named 'materialx')                                                                                            
  in "/tmp/tmp.XG16AbXwBH/adore/documentation/mkdocs/mkdocs.yaml", line 144, column 20                                                                        
cp: cannot stat 'mkdocs/site': No such file or directory                                                                                                      
/tmp/tmp.XG16AbXwBH/adore                                                                                                                                     
On branch gh-pages                                                                                                                                            
                                                                                                                                                              
No commits yet                                                                                                                                                
                                                                                                                                                              
Untracked files:                                                                                                                                              
  (use "git add <file>..." to include in what will be committed)                                                                                              
        .clang-format                                                                                                                                         
        .colcon_workspace/                                

```