### PR TITLE
changed visualizer helper port from 8765 to 9090

### DIFF
--- a/adore_scenarios/scenario_helpers/visualizer.py
+++ b/adore_scenarios/scenario_helpers/visualizer.py
@@ -15,7 +15,7 @@ from launch_ros.actions import Node
 import os
 
 
-def create_visualization_nodes(whitelist, asset_folder, visualization_offset, ns="visualizer", port=8765, send_buffer_limit=500000000):
+def create_visualization_nodes(whitelist, asset_folder, visualization_offset, ns="visualizer", port=9090, send_buffer_limit=500000000):
     """
     Returns a list of nodes for visualization (foxglove bridge and visualizer).
 


### PR DESCRIPTION
## Description

The python scenario helpers, visualizer has been changed from port 8765 to 9090 to fix not-connecting behavior.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have performed a self-review of my own code.
- [x] My last commit was made with the `--signoff` flag as required by the Eclipse Foundation.