### PR TITLE
Removed caches as dependency from map downloader test

### DIFF
--- a/adore_test_programs/adore_map_downloader_test/CMakeLists.txt
+++ b/adore_test_programs/adore_map_downloader_test/CMakeLists.txt
@@ -9,7 +9,6 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # Dependencies
 find_package(adore_map REQUIRED)
-find_package(caches REQUIRED)
 
 set(basic_map_loading_from_wfs_test_SRCS
    basic_map_loading_from_wfs_test.cpp
@@ -26,7 +25,6 @@ target_include_directories(basic_map_loading_from_wfs_test
 target_link_libraries(basic_map_loading_from_wfs_test
   PUBLIC
      adore_map::adore_map
-     caches::caches
 )
 
 install(TARGETS basic_map_loading_from_wfs_test


### PR DESCRIPTION
## Description

Please provide a brief summary of the changes you made and why they are necessary.

This PR is related to the feature to download maps directly from WFS. The PR removes dependencies on library caches from adore_test_programs/adore_map_downloader_test/CMakeLists.txt. This is related to thirteen (13) currently active micro-PRs with a similar motivation: They all remove on line in CMakeLists, a find_package command for caches (for a list, see below Section "Related Issues").

This line had been inserted as a workaround for a building issue. This has recently become obsolete by commit https://github.com/eclipse-adore/adore_map/commit/8d0b31adb5780a6cbf846d409444235c0584dfd3 by @akoerner1 (thanks a lot!)

## Type of Change

Please delete options that are not relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (adds or updates documentation)
- [ ] Refactor (non-breaking change for code readability/structure)
- [x] Other (please describe): Cleaning up (removal of an obsolete workaround)

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have signed and submitted the Eclipse Foundation Contributors Agreement: https://www.eclipse.org/legal/eca/.
- [x] My last commit was made with the `--signoff` flag as required by the Eclipse Foundation.
- [x] I have commented my code, particularly in hard-to-understand areas and provided a README.md when necessary.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] Tests pass locally with my changes: (run 'make test' on the ADORe project root to run unit tests).
- [ ] I have updated the documentation in `documentation/technical_reference_manual` where necessary.
- [ ] I have updated the `THIRD-PARTY.md` if I have introduced new third-party libraries or dependencies to the project.
- [ ] I have updated the `CONTRIBUTERS.md` if I wish to acknowledged for my contribution.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so others can reproduce.

- adore/adore_test_programs/adore_map_downloader_test/basic_map_loading_from_wfs_test.cpp: after building and providing the password for adore-ts_reader in adore/adore_test_programs/adore_map_downloader_test/config/r2s_wfs_config_bs.json, start the development environment a second time and go to  .colcon_workspace/install/adore_map_downloader_test/bin and call ./basic_map_loading_from_wfs_test w/o parameters. I.a., you should see a line "All tests passed successfully, good!".
 
- unit tests (in particular the ones related to MapDownloadCacheTest.* and MapTest.*): they should pass

- 'just ci' (outside the development environment): should finish without failing

**Test Configuration**:
- OS: Ubuntu Linux (Noble Numbat)
- Docker Version: 28.4.0

## Screenshots (if applicable)

Include any relevant screenshots or videos to demonstrate the feature/fix.

## Related Issues

For your convenience, here is a list of the aforementioned micro-PRs (each such PR just removes a similar line of code, i.e. cleans up an obsolete workaround):

- [PR 8 of adore_map](https://github.com/eclipse-adore/adore_map/pull/8)
- [PR 7 of adore_dynamics](https://github.com/eclipse-adore/adore_dynamics/pull/7)
- [PR 6 of adore_planning](https://github.com/eclipse-adore/adore_planning/pull/6)
- [PR 13 of adore_decision_maker](https://github.com/eclipse-adore/adore_decision_maker/pull/13)
- [PR 15 of adore_visualizer](https://github.com/eclipse-adore/adore_visualizer/pull/15)
- [PR 8 of adore_simulated_vehicle](https://github.com/eclipse-adore/adore_simulated_vehicle/pull/8)
- [PR 4 of adore_map_conversions](https://github.com/eclipse-adore/adore_map_conversions/pull/4)
- [PR 5 of adore_dynamics_conversions](https://github.com/eclipse-adore/adore_dynamics_conversions/pull/5)
- [PR 18 of adore_if_carla](https://github.com/eclipse-adore/adore_if_carla/pull/18)
- [PR 7 of adore_controllers](https://github.com/eclipse-adore/adore_controllers/pull/7)
- [PR 6 of adore_trajectory_tracker](https://github.com/eclipse-adore/adore_trajectory_tracker/pull/6)
- [PR 5 of adore_mission_control](https://github.com/eclipse-adore/adore_mission_control/pull/5)
- [PR 6 of adore_decision_maker_infrastructure](https://github.com/eclipse-adore/adore_decision_maker_infrastructure/pull/6)


## Notes for Reviewers

This PR is best merged after merging the above micro-PRs. I can update the hashes of the submodules here for this PR, then. Thank you very much in advance!
